### PR TITLE
WIP: chore(matrix): use `centos-7` for `2017.7`

### DIFF
--- a/matrix.csv
+++ b/matrix.csv
@@ -18,7 +18,7 @@ debian,8,2018.3,stable,2
 fedora,28,2018.3,git,2
 opensuse/leap,42,2018.3,git,2
 ubuntu,16.04,2018.3,stable,2
-centos,6,2017.7,stable,2
+centos,7,2017.7,stable,2
 debian,8,2017.7,stable,2
 fedora,28,2017.7,git,2
 opensuse/leap,42,2017.7,git,2


### PR DESCRIPTION
* Use at least while `centos-6` not available

---

Opening for discussion.  The idea is that every `os` can be tested with every salt version, leaving a nice `5 x 3 = 15` base matrix for testing formulas.