### PR TITLE
refactor(matrix): use `15.1` tag specifically for `opensuse/leap`

### DIFF
--- a/matrix.csv
+++ b/matrix.csv
@@ -46,11 +46,11 @@ fedora,29,2018.3,git,3
 fedora,29,2017.7,git,2
 
 # OPENSUSE
-opensuse/leap,15,develop,git,3
-opensuse/leap,15,2019.2,git,3
-opensuse/leap,15,2019.2,git,2
-opensuse/leap,15,2018.3,git,2
-opensuse/leap,15,2017.7,git,2
+opensuse/leap,15.1,develop,git,3
+opensuse/leap,15.1,2019.2,git,3
+opensuse/leap,15.1,2019.2,git,2
+opensuse/leap,15.1,2018.3,git,2
+opensuse/leap,15.1,2017.7,git,2
 
 # UBUNTU
 ubuntu,18.04,develop,git,3


### PR DESCRIPTION
* `15` will get the latest version in that series
* No differentiation between `15.0` and planned release `15.2`
  - https://en.opensuse.org/Portal:15.2
  - https://en.opensuse.org/openSUSE:Roadmap
* Identified while collating:
  - https://github.com/saltstack-formulas/template-formula/wiki/Pre-salted-images-from-Netmanagers

---

@javierbertoli To maintain consistency of using version numbers, I propose using the minor number specifically.  That allows for both `15.0` (which is still supported until 30/11/19) and for a better update to `15.2` when that is finally released.