### PR TITLE
fix(prepare): remove duplicate `net-tools` from `${O_PKGS}`

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -82,7 +82,7 @@ case ${OS} in
     dnf -y update && dnf -y install ${F_PKGS}
     ;;
   opensuse*)
-    O_PKGS="${COMMON_PKGS} glibc-locale net-tools openssh which"
+    O_PKGS="${COMMON_PKGS} glibc-locale openssh which"
 
     if [ "${PY_VER}" = "3" ]; then
       O_PKGS="${O_PKGS} python3-pip"


### PR DESCRIPTION
* Already available in `${COMMON_PKGS}`

---

Found when working on:

* https://github.com/myii/ssf-formula/pull/52
* https://github.com/myii/ssf-formula/pull/53

Further suggestion: how about sorting these alphabetically, within each set of quotes?  E.g.

```diff
-    D_PKGS="${COMMON_PKGS} locales procps openssh-server lsb-release"
+    D_PKGS="${COMMON_PKGS} locales lsb-release openssh-server procps"
```