### PR TITLE
fix(debian-10): provide `python3-apt` extra package by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ env:
     - DN=centos DV=6 PI=yum SV=2017.7 SIM=stable PV=2 EP="python-pip"
 
     # DEBIAN
-    - DN=debian DV=10 PI=apt SV=master SIM=git    PV=3 EP="python3-pip"
+    - DN=debian DV=10 PI=apt SV=master SIM=git    PV=3 EP="python3-apt python3-pip"
     - DN=debian DV=10 PI=apt SV=2019.2 SIM=stable PV=3 EP="python3-pip"
     # There's no Py2 repo for debian10 so the bootstrap fails any attempt to install dependencies to
     # install 2018.3 from git. Also, there's no 2018.3 repo in buster (neither py2 or py3), so trying


### PR DESCRIPTION
* A number of formulas are failing when using any `pkgrepo` states
* Examples of current workarounds:
  - https://github.com/saltstack-formulas/rabbitmq-formula/commit/89b470f7124795353a5087ac872d1e8c510f240c
  - https://github.com/saltstack-formulas/varnish-formula/pull/19/commits/11fc28613f7851d25e65b7297a2c30df2b82fd3e
* Examples of current failures:
  - https://travis-ci.org/myii/nginx-formula/jobs/615599519#L1696
  - https://travis-ci.com/saltstack-formulas/php-formula/jobs/259515786#L3398