### PR TITLE
feat: update for `neon`, `centos-8` and `amazon`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,7 @@ env:
 
     # CENTOS
     - DN=centos DV=8 PI=yum SV=master SIM=git    PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
-    # There are no RPM's for Centos8 https://repo.saltstack.com/yum/redhat/
-    # centos,8 SV=2019.2 SIM=stable PV=3
-    - DN=centos DV=8 PI=yum SV=2019.2 SIM=git    PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
+    - DN=centos DV=8 PI=yum SV=2019.2 SIM=stable PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
     - DN=centos DV=7 PI=yum SV=2019.2 SIM=stable PV=3 EP="python3 python3-pip python3-devel openssl-devel swig gcc-g++ zeromq zeromq-devel"
     - DN=centos DV=7 PI=yum SV=2019.2 SIM=stable PV=2 EP="python2-pip"
     - DN=centos DV=7 PI=yum SV=2018.3 SIM=stable PV=2 EP="python2-pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
     # AMAZONLINUX
     - DN=amazonlinux DV=2 PI=yum SV=master SIM=git    PV=3 EP="yum-utils python3-pip procps-ng"
     - DN=amazonlinux DV=2 PI=yum SV=2019.2 SIM=stable PV=3 EP="yum-utils python3-pip procps-ng"
-    - DN=amazonlinux DV=2 PI=yum SV=2018.3 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
+    - DN=amazonlinux DV=1 PI=yum SV=2019.2 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
+    - DN=amazonlinux DV=1 PI=yum SV=2018.3 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
 
     # ARCHLINUX
     # The Salt bootstrap installer does not provide packages nor installs with py3 for Arch

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   # DN: distro name (amazonlinux, archlinux, centos, debian, fedora, opensuse, ubuntu)
   # DV: distro version
   # PI: packages installer, used as dockerfile extension (deb, yum, pac, zyp)
-  # SV: salt version (master, 2019.2, 2018.3, 2017.7)
+  # SV: salt version (master, 2019.2, 2018.3)
   # SIM: salt install method (git, stable)
   # PV: python version (3, 2)
   # EP: extra packages required for the specific build
@@ -26,7 +26,6 @@ env:
     - DN=amazonlinux DV=2 PI=yum SV=master SIM=git    PV=3 EP="yum-utils python3-pip procps-ng"
     - DN=amazonlinux DV=2 PI=yum SV=2019.2 SIM=stable PV=3 EP="yum-utils python3-pip procps-ng"
     - DN=amazonlinux DV=2 PI=yum SV=2018.3 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
-    - DN=amazonlinux DV=2 PI=yum SV=2017.7 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
 
     # ARCHLINUX
     # The Salt bootstrap installer does not provide packages nor installs with py3 for Arch
@@ -34,7 +33,6 @@ env:
     - DN=archlinux/base DV=latest PI=pac SV=master SIM=git PV=2 EP="openssl openssh awk procps python2-pip"
     - DN=archlinux/base DV=latest PI=pac SV=2019.2 SIM=git PV=2 EP="openssl openssh awk procps python2-pip"
     - DN=archlinux/base DV=latest PI=pac SV=2018.3 SIM=git PV=2 EP="openssl openssh awk procps python2-pip"
-    - DN=archlinux/base DV=latest PI=pac SV=2017.7 SIM=git PV=2 EP="openssl openssh awk procps python2-pip"
 
     # CENTOS
     - DN=centos DV=8 PI=yum SV=master SIM=git    PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
@@ -43,7 +41,6 @@ env:
     - DN=centos DV=7 PI=yum SV=2019.2 SIM=stable PV=2 EP="python2-pip"
     - DN=centos DV=7 PI=yum SV=2018.3 SIM=stable PV=2 EP="python2-pip"
     - DN=centos DV=6 PI=yum SV=2018.3 SIM=stable PV=2 EP="python27-pip"
-    - DN=centos DV=6 PI=yum SV=2017.7 SIM=stable PV=2 EP="python27-pip"
 
     # DEBIAN
     - DN=debian DV=10 PI=apt SV=master SIM=git    PV=3 EP="python3-apt python3-pip"
@@ -55,23 +52,19 @@ env:
     - DN=debian DV=9 PI=apt SV=2019.2 SIM=stable PV=3 EP="python3-pip"
     - DN=debian DV=9 PI=apt SV=2018.3 SIM=stable PV=2 EP="python-pip"
     - DN=debian DV=8 PI=apt SV=2018.3 SIM=stable PV=2 EP="python-pip"
-    - DN=debian DV=8 PI=apt SV=2017.7 SIM=stable PV=2 EP="python-pip"
 
     # FEDORA
     # Fedora has no python3 packages due to a tornado issue,
     # but they ship with Python3 since 29, so we install it using git
     # https://bugzilla.redhat.com/show_bug.cgi?id=1723207
-    # except for 2017.7, which does not run on python3
     - DN=fedora DV=31 PI=dnf SV=master SIM=git PV=3 EP="python3-pip"
     - DN=fedora DV=31 PI=dnf SV=2019.2 SIM=git PV=3 EP="python3-pip"
     - DN=fedora DV=30 PI=dnf SV=2018.3 SIM=git PV=3 EP="python3-pip"
-    - DN=fedora DV=30 PI=dnf SV=2017.7 SIM=git PV=2 EP="python-pip"
 
     # OPENSUSE
     - DN=opensuse/leap DV=15.1 PI=zyp SV=master SIM=git PV=3 EP="python3-pip"
     - DN=opensuse/leap DV=15.1 PI=zyp SV=2019.2 SIM=git PV=3 EP="python3-pip"
     - DN=opensuse/leap DV=15.1 PI=zyp SV=2018.3 SIM=git PV=2 EP="python-pip"
-    - DN=opensuse/leap DV=15.1 PI=zyp SV=2017.7 SIM=git PV=2 EP="python-pip"
 
     # UBUNTU
     - DN=ubuntu DV=18.04 PI=apt SV=master SIM=git    PV=3 EP="python3-pip"
@@ -80,7 +73,6 @@ env:
     - DN=ubuntu DV=18.04 PI=apt SV=2018.3 SIM=stable PV=2 EP="python-pip"
     - DN=ubuntu DV=16.04 PI=apt SV=2019.2 SIM=stable PV=3 EP="python3-pip"
     - DN=ubuntu DV=16.04 PI=apt SV=2018.3 SIM=stable PV=2 EP="python-pip"
-    - DN=ubuntu DV=16.04 PI=apt SV=2017.7 SIM=stable PV=2 EP="python-pip"
 
 # adding the inspec license-accepted file as different lines because of
 # https://travis-ci.community/t/multiline-commands-have-two-spaces-in-front-breaks-heredocs/2756/4

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,8 @@ env:
   # EP: extra packages required for the specific build
   jobs:
     # AMAZONLINUX
-    # AmazonLinux packages are py2, even if the installer says
-    # it's using python3. Dependencies are hardcoded to py2
-    # amazonlinux,2 SV=master SIM=git PV=3
-    # amazonlinux,2 SV=2019.2 SIM=stable PV=3
+    - DN=amazonlinux DV=2 PI=yum SV=master SIM=git    PV=3 EP="yum-utils python3-pip procps-ng"
+    - DN=amazonlinux DV=2 PI=yum SV=2019.2 SIM=stable PV=3 EP="yum-utils python3-pip procps-ng"
     - DN=amazonlinux DV=2 PI=yum SV=2018.3 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
     - DN=amazonlinux DV=2 PI=yum SV=2017.7 SIM=stable PV=2 EP="yum-utils python-pip procps-ng"
 

--- a/Dockerfile.yum
+++ b/Dockerfile.yum
@@ -30,6 +30,11 @@ RUN if [ "${DISTRO_NAME}" = "centos" -a "${DISTRO_VERSION}" = "6" ]; \
     then yum -y update && yum -y install $EXTRA_PACKAGES; \
          ln -s /usr/bin/pip2.7 /usr/bin/pip; \
     fi
+# Amazon 1 installs python26-pip
+RUN if [ "${DISTRO_NAME}" = "amazonlinux" -a "${DISTRO_VERSION}" = "1" ]; \
+    then yum -y update && yum -y install $EXTRA_PACKAGES; \
+         ln -s /usr/bin/pip-2.6 /usr/bin/pip; \
+    fi
 RUN rm -rf /var/cache/{salt,yum} \
  && (find / -name "*pyc" ; find / -name "__pycache__") |grep -v /proc | xargs rm -rf
 

--- a/test/integration/controls/salt_pkgs.rb
+++ b/test/integration/controls/salt_pkgs.rb
@@ -1,4 +1,4 @@
-salt_version = input('salt_version') == 'master' ? 'Fluorine' : input('salt_version')
+salt_version = input('salt_version') == 'master' ? 'Neon' : input('salt_version')
 python_version = input('py_version') == '3' ? '3' : '2'
 
 control 'salt call' do


### PR DESCRIPTION
#### test(salt_pkgs): update `master` to `Neon`

Required, since the `master` branch is now `neon`.

---

#### fix(travis): use `SIM=stable` for `centos-8`

https://freenode.logbot.info/salt/20200119#c3112474-c3112476

> -|-|-
> :-:|---|---
> 23:58 | overyander | myii, FYI github.com/netmanagers/salt-image-builder/blob/master/.travis.yml#L43 is referencing the wrong URL for Centos 8
> 23:58 | overyander | From the salt downloads page, repo.saltstack.com/py3/redhat has the repos for el8 (Centos and RHEL)
> 23:59 | overyander | which have the latest salt-minion-2019.2.3-1.el8.noarch.rpm

---

#### fix(travis): provide `amazonlinux-2-py3` images

These are now working.  Closes #16.

---

#### feat(neon_rc): build images for `v3000.0rc2`

For discussion, are these worth providing?  I believe there is some use for these.  Since `neon` is approaching, we should be testing it more than we currently are.

1. **Current**: `master` x1, `2019.2` x3
1. **Proposed**: `master` x1, `v3000.0rc2` x1, `2019.2` x2

---

#### feat(amazonlinux-1): provide images for this platform

These also build now.  While old, these are still used, such as in the [`vault-formula`](https://github.com/saltstack-formulas/vault-formula/blob/1ab38018c69130a62c19006b81a324afdfc1bf67/kitchen.yml#L15-L21`) (CC: @dafyddj).  If going ahead with this, obviously can reduce the number of `amazonlinux` images overall, as done for the other platforms.

---

I didn't worry about the alignment formatting in `.travis.yml` so far; once the final decisions have been made, I'll update the PR before it is merged.