### PR TITLE
test(salt_pkgs): update `master` to `3000` (version number for `Neon`)

### DIFF
--- a/test/integration/controls/salt_pkgs.rb
+++ b/test/integration/controls/salt_pkgs.rb
@@ -1,4 +1,4 @@
-salt_version = input('salt_version') == 'master' ? 'Neon' : input('salt_version')
+salt_version = input('salt_version') == 'master' ? '3000' : input('salt_version')
 python_version = input('py_version') == '3' ? '3' : '2'
 
 control 'salt call' do


### PR DESCRIPTION
@javierbertoli Now that https://github.com/saltstack/salt-bootstrap/pull/1424 has been merged, this should get the build working again.