### PR TITLE
fix(ubuntu-1804): provide `python3-apt` extra package by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ env:
     - DN=opensuse/leap DV=15.1 PI=zyp SV=2018.3 SIM=git PV=2 EP="python-pip"
 
     # UBUNTU
-    - DN=ubuntu DV=18.04 PI=apt SV=master SIM=git    PV=3 EP="python3-pip"
+    - DN=ubuntu DV=18.04 PI=apt SV=master SIM=git    PV=3 EP="python3-apt python3-pip"
     - DN=ubuntu DV=18.04 PI=apt SV=2019.2 SIM=stable PV=3 EP="python3-pip"
     - DN=ubuntu DV=18.04 PI=apt SV=2019.2 SIM=stable PV=2 EP="python-pip"
     - DN=ubuntu DV=18.04 PI=apt SV=2018.3 SIM=stable PV=2 EP="python-pip"


### PR DESCRIPTION
* Same reasoning as 50e22aba7a637ebf427f5e7ddba470c83133e81a
* E.g. `apt-formula`:
  - `Converge failed on instance <repositories-ubuntu-1804-master-py3>`