### PR TITLE
Avoid unnecessary files in apt images

### DIFF
--- a/Dockerfile.apt
+++ b/Dockerfile.apt
@@ -13,6 +13,10 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 ARG PKGS="udev git net-tools sudo curl locales procps openssh-server lsb-release $EXTRA_PACKAGES"
 
+# Avoid unnecessary files when installing packages
+COPY files/dpkg-nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
+COPY files/apt-no-recommends /etc/apt/apt.conf.d/99synaptic
+
 RUN apt update \
  && apt install --yes $PKGS
 

--- a/files/apt-no-recommends
+++ b/files/apt-no-recommends
@@ -1,0 +1,2 @@
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";

--- a/files/dpkg-nodoc
+++ b/files/dpkg-nodoc
@@ -1,0 +1,22 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/kde/HTML/C/*
+# we need to keep copyright files for legal reasons
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/info/*
+# lintian stuff is small, but really unnecessary
+path-exclude /usr/share/lintian/overrides/*
+path-exclude /usr/share/linda/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/locale.alias
+path-include /usr/share/locale/languages
+path-include /usr/share/locale/all_languages
+path-include /usr/share/locale/currency/*
+path-include /usr/share/locale/l10n/*
+path-exclude /usr/share/gnome/help/*/*
+path-exclude /usr/share/doc/kde/HTML/*/*
+path-exclude /usr/share/omf/*/*-*.emf
+path-include /usr/share/gnome/help/*/C/*
+path-include /usr/share/doc/kde/HTML/C/*
+path-include /usr/share/omf/*/*-C.emf


### PR DESCRIPTION
Shrink apt images size by not installing unneeded files like documentation.