### PR TITLE
Remove getty and udev targets to lower CPU usage

### DIFF
--- a/Dockerfile.apt
+++ b/Dockerfile.apt
@@ -11,7 +11,7 @@ ARG EXTRA_PACKAGES=""
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
-ARG PKGS="udev git net-tools sudo curl locales procps openssh-server lsb-release systemd $EXTRA_PACKAGES"
+ARG PKGS="udev git net-tools sudo curl locales procps openssh-server lsb-release systemd systemd-sysv $EXTRA_PACKAGES"
 
 # Avoid unnecessary files when installing packages
 COPY files/dpkg-nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
@@ -19,6 +19,10 @@ COPY files/apt-no-recommends /etc/apt/apt.conf.d/99synaptic
 
 RUN apt update \
  && apt install --yes $PKGS
+
+# Remove unnecessary getty and udev targets that result in high CPU usage when using
+# multiple containers with Molecule or Kitchen (https://github.com/ansible/molecule/issues/1104)
+RUN rm -f /lib/systemd/system/systemd*udev* /lib/systemd/system/getty.target
 
 # Use @vutny's suggestion in https://github.com/saltstack-formulas/postgres-formula/pull/269#issuecomment-492597286
 RUN rm -f /etc/default/locale /etc/locale.gen


### PR DESCRIPTION
Remove systemd's getty and udev targets to lower CPU usage when using containers