### PR TITLE
feat(centos-7-py2): replace with `py3` due to Testinfra/InSpec failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ env:
     - DN=centos DV=8 PI=yum SIM=stable SV=3000   PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
     - DN=centos DV=8 PI=yum SIM=stable SV=2019.2 PV=3 EP="python3 python3-pip python3-devel openssl-devel swig glibc-langpack-en"
     - DN=centos DV=7 PI=yum SIM=stable SV=2019.2 PV=3 EP="python3 python3-pip python3-devel openssl-devel swig gcc-g++ zeromq zeromq-devel"
-    - DN=centos DV=7 PI=yum SIM=stable SV=2019.2 PV=2 EP="python2-pip"
-    - DN=centos DV=7 PI=yum SIM=stable SV=2018.3 PV=2 EP="python2-pip"
+    - DN=centos DV=7 PI=yum SIM=stable SV=2018.3 PV=3 EP="python3 python3-pip python3-devel openssl-devel swig gcc-g++ zeromq zeromq-devel"
     - DN=centos DV=6 PI=yum SIM=stable SV=2018.3 PV=2 EP="python27-pip"
 
     # DEBIAN

--- a/Dockerfile.zyp
+++ b/Dockerfile.zyp
@@ -22,9 +22,6 @@ RUN if [ ! -e /etc/SuSE-release ]; then ln -s /etc/os-release /etc/SuSE-release;
 RUN curl -L https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.sh | \
     sudo sh -s -- -XUdfP -x python$PYTHON_VERSION $SALT_INSTALL_METHOD $SALT_VERSION
 
-# FIXME: Remove this temporary workaround when `repo.saltstack.com` is fixed
-RUN sed -i -e 's:staging/::g' /etc/zypp/repos.d/systemsmanagement_saltstack_products.repo && zypper --gpg-auto-import-keys refresh
-
 RUN rm -rf /var/cache/{salt,zyp} \
  && (find / -name "*pyc" ; find / -name "__pycache__") |grep -v /proc | xargs rm -rf
 


### PR DESCRIPTION
Our current test run still has failures on both `centos-7-py2` runs, causing the `cron` run to fail:

* https://travis-ci.com/github/netmanagers/salt-image-builder/builds/152315875
  - Both failures are at the Testinfra stage, where it can't get the output from `salt-call`.
  - Note: Salt appears to install fine and `salt-call` can be used within Docker itself.

I've done some investigating but I haven't been able to get this to work:

1. Tested with the original InSpec tests.
1. Borrowed the package lists from the `centos-7-py3` job (adjusted accordingly).
1. Run the bootstrap locally in debug mode to look for issues.

I've run out of time to fix this and there's little motivation to get `py2` working since it's deprecated.  The proposal here is to simply only use `py3` for `centos-7`, which is working fine.

---

The second commit is to reset the workaround that was introduced to get the [OpenSUSE images building](https://github.com/netmanagers/salt-image-builder/pull/29#issuecomment-597632863).  This was resolved in the #releases channel in Slack:

> 12:28 Imran Iqbal
> @​Daithi We've been having a number of issues with OpenSUSE Leap 15.1 when attempting to install from the bootstrap.  Eventually tracked it down to the repo itself: https://repo.saltstack.com/opensuse/openSUSE_Leap_15.1/systemsmanagement:saltstack:products.repo.  This still contains `staging` in both URLs, which is no longer correct.
> 
> 13:52 David Murphy
> @​myii We mirror the SUSE packages and have been inform that we need to pull from another location but they have yet to inform SaltStack as to where we should be mirroring from.
> SUSE build the Salt packages for the SUSE platforms, we are providing a mirror as a convenience
> 
> 13:54 Imran Iqbal
> @​Daithi Is there an appropriate workaround from the bootstrap?  Otherwise, it keeps preparing the repo with the `staging` URLs, which always fail.
> Right now, we're resorting to adjusting `/etc/zypp/repos.d/systemsmanagement_saltstack_products.repo` manually and then running `zypper --gpg-auto-import-keys refresh` (in our `Dockerfile`).
> 
> 14:27 David Murphy
> Looking at that and see what you mean, talking with our SRE's to get this addressed, applies to all of the SUSE mirrors that we are providing
> 
> 15:04 Jochen Breuer
> @​Daithi For openSUSE I send @​s0undt3ch the links. But I'm afraid there is simply no way for you to mirror the final packages. But why are you doing that anyway?
> 
> 16:13 Jochen Breuer
> Sorry, the final packages for SLE. 
> You only get those with a subscription. All of the other repos like `systemsmanagement:saltstack:products` are not yet fully tested and might still have bugs. Also if you’ve got SLES and you install salt from anywhere but the official repo, you are out of support. 
> 
> 16:33 David Murphy
> @​brejoc the problem is in the url's in repo.saltstack.com still left pointing to repo.saltstack.com/staging
> Thanks for that update on only able to get latest with subscription
> We were mirroring since customers were expecting to be able to get SUSE from us too, kind of one-stop-shop, and have been doing this for a few years
> @​myii The issue should be fixed now, can you check to make sure you don't have any more issues with bootstrap
> 
> 06:00 Imran Iqbal
> @​Daithi Yes, I've tested and it's all working properly now, thanks for the quick turnaround.