### PR TITLE
feat: add new platforms (`ubuntu-20.04`, `fedora-32` & `opensuse-leap-15.2`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,9 @@ env:
     - DN=fedora         DV=31     PI=dnf SIM=git    SV=2019.2 PV=3 EP="python3-pip"
 
     # OPENSUSE
-    - DN=opensuse/leap  DV=15.1   PI=zyp SIM=git    SV=master PV=3 EP="python3-pip"
-    - DN=opensuse/leap  DV=15.1   PI=zyp SIM=git    SV=3000.3 PV=3 EP="python3-pip"
-    - DN=opensuse/leap  DV=15.1   PI=zyp SIM=git    SV=2019.2 PV=3 EP="python3-pip"
+    - DN=opensuse/leap  DV=15.2   PI=zyp SIM=git    SV=master PV=3 EP="python3-pip"
+    - DN=opensuse/leap  DV=15.2   PI=zyp SIM=git    SV=3000.3 PV=3 EP="python3-pip"
+    - DN=opensuse/leap  DV=15.2   PI=zyp SIM=git    SV=2019.2 PV=3 EP="python3-pip"
 
     # UBUNTU
     - DN=ubuntu         DV=20.04  PI=apt SIM=git    SV=master PV=3 EP="python3-apt python3-pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ env:
     # Fedora has no python3 packages due to a tornado issue,
     # but they ship with Python3 since 29, so we install it using git
     # https://bugzilla.redhat.com/show_bug.cgi?id=1723207
+    - DN=fedora         DV=32     PI=dnf SIM=git    SV=master PV=3 EP="python3-pip"
     - DN=fedora         DV=31     PI=dnf SIM=git    SV=master PV=3 EP="python3-pip"
     - DN=fedora         DV=31     PI=dnf SIM=git    SV=3000.3 PV=3 EP="python3-pip"
     - DN=fedora         DV=31     PI=dnf SIM=git    SV=2019.2 PV=3 EP="python3-pip"
@@ -65,6 +66,7 @@ env:
     - DN=opensuse/leap  DV=15.1   PI=zyp SIM=git    SV=2019.2 PV=3 EP="python3-pip"
 
     # UBUNTU
+    - DN=ubuntu         DV=20.04  PI=apt SIM=git    SV=master PV=3 EP="python3-apt python3-pip"
     - DN=ubuntu         DV=18.04  PI=apt SIM=git    SV=master PV=3 EP="python3-apt python3-pip"
     - DN=ubuntu         DV=18.04  PI=apt SIM=stable SV=3000.3 PV=3 EP="python3-pip"
     - DN=ubuntu         DV=18.04  PI=apt SIM=stable SV=3000.3 PV=2 EP="python-pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,9 +119,6 @@ notifications:
       - 'chat.freenode.net#salt-image-builder'
     on_success: always  # default: always
     on_failure: always  # default: always
-    on_start: always    # default: never
-    on_cancel: always   # default: always
-    on_error: always    # default: always
   webhooks:
     if: 'repo = netmanagers/salt-image-builder'
     urls:

--- a/test/integration/test_salt_version.py
+++ b/test/integration/test_salt_version.py
@@ -1,7 +1,7 @@
 def test_salt_version(host, saltvers):
     cmd = host.run("salt-call --version")
     if saltvers in ["latest", "master"]:
-        saltvers = "3000"
+        saltvers = "3001"
     assert saltvers in cmd.stdout
     assert cmd.rc == 0
 


### PR DESCRIPTION
feat(python38): add `ubuntu-20.04` & `fedora-32` for `master` only

* Upstream `master` branch is now Sodium `3001`
* Upstream issue resolved for `Python 3.8 Support`:
  - https://github.com/saltstack/salt/issues/55310

---

Already tested the images built by this in the `tomcat-formula`:

* https://travis-ci.org/github/myii/tomcat-formula/builds/690531847