### PR TITLE
Handle version branch when installing from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
 
 script:
   - docker run --detach=true --name "testinfra-${TAG}-${PI}-${PV}-${SIM}-${SV}" "${TAG}" tail -f /dev/null
-  - venv/bin/pytest --hosts="docker://testinfra-${TAG}-${PI}-${PV}-${SIM}-${SV}" test/integration --pyvers "${PV}" --saltvers "${SV}" -v
+  - venv/bin/pytest --hosts="docker://testinfra-${TAG}-${PI}-${PV}-${SIM}-${SV}" test/integration --pyvers "${PV}" --saltvers "${SV}" --installmethod "${SIM}" -v
   - docker stop "testinfra-${TAG}-${PI}-${PV}-${SIM}-${SV}"
   - docker rm "testinfra-${TAG}-${PI}-${PV}-${SIM}-${SV}"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 def pytest_addoption(parser):
     parser.addoption("--pyvers", action="store", default="3")
     parser.addoption("--saltvers", action="store", default="3000")
+    parser.addoption("--installmethod", action="store", default="stable")
 
 
 def pytest_generate_tests(metafunc):
@@ -12,3 +13,6 @@ def pytest_generate_tests(metafunc):
     option_value = metafunc.config.option.saltvers
     if 'saltvers' in metafunc.fixturenames and option_value is not None:
         metafunc.parametrize("saltvers", [option_value])
+    option_value = metafunc.config.option.installmethod
+    if 'installmethod' in metafunc.fixturenames and option_value is not None:
+        metafunc.parametrize("installmethod", [option_value])

--- a/test/integration/test_salt_version.py
+++ b/test/integration/test_salt_version.py
@@ -1,7 +1,11 @@
-def test_salt_version(host, saltvers):
+def test_salt_version(host, saltvers, installmethod):
     cmd = host.run("salt-call --version")
     if saltvers in ["latest", "master"]:
         saltvers = "3001"
+    # Handle version branch when installing from git, remove leading "v"
+    # v3001rc1 becomes 3001rc1
+    if saltvers.startswith("v") and installmethod == "git":
+        saltvers = saltvers[1:]
     assert saltvers in cmd.stdout
     assert cmd.rc == 0
 


### PR DESCRIPTION
In saltstack/salt repo, version branches are named `v<version>`. 

When instaling through git (SIM=git) version comparison fails for version branches (you can try with `SIM=git SV=v3001rc1`)

This PR handles that situation and allows you to build an image from a version branch with git install method